### PR TITLE
A bunch of random cleanups, including adding back dynmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the container. On my personal server I've done this:
 ```bash
 mkdir -p /var/lib/minecraft/{world,backups}
 docker run \
-  -v /var/lib/minecraft/world:/home/minecraft/mcmyadmin/Minecraft/world \
+  -v /var/lib/minecraft/world:/opt/minecraft/world \
   -v /var/lib/minecraft/backups:/home/minecraft/mcmyadmin/Backups \
   --name minecraft \
   feedthebeast/beyond

--- a/build.py
+++ b/build.py
@@ -1,7 +1,25 @@
+import argparse
 import os
 import bs4
 import requests
 import subprocess
+
+
+DYNMAP_URLS = {
+    "1.4.7": "https://minecraft.curseforge.com/projects/dynmapforge/files/2216525/download",
+    "1.5.2": "https://minecraft.curseforge.com/projects/dynmapforge/files/2216526/download",
+    "1.6.4": "https://minecraft.curseforge.com/projects/dynmapforge/files/2307077/download",
+    "1.7.10": "https://minecraft.curseforge.com/projects/dynmapforge/files/2380586/download",
+    "1.8.0": "https://minecraft.curseforge.com/projects/dynmapforge/files/2380592/download",
+    "1.8.9": "https://minecraft.curseforge.com/projects/dynmapforge/files/2380593/download",
+    "1.9": "https://minecraft.curseforge.com/projects/dynmapforge/files/2380594/download",
+    "1.9.4": "https://minecraft.curseforge.com/projects/dynmapforge/files/2380600/download",
+    "1.10.2": "https://minecraft.curseforge.com/projects/dynmapforge/files/2380601/download",
+    "1.11": "https://minecraft.curseforge.com/projects/dynmapforge/files/2380602/download",
+    "1.11.2": "https://minecraft.curseforge.com/projects/dynmapforge/files/2380603/download",
+    "1.12": "https://minecraft.curseforge.com/projects/dynmapforge/files/2436596/download",
+    "1.12.2": "https://minecraft.curseforge.com/projects/dynmapforge/files/2645936/download"
+}
 
 
 class Modpack:
@@ -19,15 +37,26 @@ class Modpack:
         self.server_pack = server_pack
         self.repo_version = repo_version
 
+    def __repr__(self):
+        from pprint import pformat
+        return "<" + type(self).__name__ + "> " + pformat(vars(self), indent=4, width=1)
 
-def do_build(docker_tag, download_url):
-    command = 'docker build ./modserver -t "'+docker_tag+'" --build-arg DOWNLOAD_URL='+download_url
 
-    buildProcess = subprocess.Popen(command, shell=True)
-    os.waitpid(buildProcess.pid, 0)
+def do_build(docker_tag, download_url, dynmap_url):
+    command = 'docker build ./modserver -t "%s" --build-arg DOWNLOAD_URL=%s --build-arg DYNMAP_URL=%s' % (
+        docker_tag, download_url, dynmap_url
+    )
 
-    pushProcess = subprocess.Popen('docker push '+docker_tag, shell=True)
-    os.waitpid(pushProcess.pid, 0)
+    if not args.silent:
+        print(command)
+
+    if not args.dryrun:
+        buildProcess = subprocess.Popen(command, shell=True)
+        os.waitpid(buildProcess.pid, 0)
+
+    if not args.dryrun:
+        pushProcess = subprocess.Popen('docker push ' + docker_tag, shell=True)
+        os.waitpid(pushProcess.pid, 0)
 
 
 def docker_tag(name, pack_version="", mc_version="", latest=False):
@@ -47,27 +76,44 @@ def build_modpack(modpack):
 
     versions.append(modpack.version)
 
-    builds = []
+    builds = {}
 
     for v in versions:
         download_url = "http://ftb.cursecdn.com/FTB2/modpacks/"+modpack.dir+"/"+v.replace('.','_')+"/"+modpack.server_pack
+        dynmap_url = DYNMAP_URLS[modpack.mc_version]
 
-        builds.append((docker_tag(modpack.dir.lower(), v, modpack.mc_version), download_url))
         if v == modpack.version:
-            builds.append((docker_tag(modpack.dir.lower(), latest=True), download_url))
+            builds['latest'] = (docker_tag(modpack.dir.lower(), latest=True), download_url, dynmap_url)
 
-    for bt in builds:
+        if not args.latest:
+            builds[v] = (docker_tag(modpack.dir.lower(), v, modpack.mc_version), download_url, dynmap_url)
 
-        r = requests.get("https://index.docker.io/v1/repositories/"+bt[0][0]+"/tags/"+bt[0][1])
-        if r.status_code == 404:
-            print("Building feedthebeast/" + bt[0][0] + ":" + bt[0][1])
-            do_build(':'.join(bt[0]), bt[1])
+    for key, bt in builds.items():
+        tag = args.prefix + bt[0][0] + ":" + bt[0][1]
+        if not args.prefix:
+            r = requests.get("https://index.docker.io/v1/repositories/"+bt[0][0]+"/tags/"+bt[0][1])
+            if r.status_code != 404:
+                continue
+        if not args.silent:
+            print("Building " + tag)
+        do_build(tag, bt[1], bt[2])
 
 
 def main():
+    global args
+
+    parser = argparse.ArgumentParser(allow_abbrev=True)
+    parser.add_argument('-m', '--modpack', dest='modpack', action='store', help='Limit to single modpack')
+    parser.add_argument('-l', '--latest', dest='latest', action='store_true', help='Limit to the latest tag for a modpack')
+    parser.add_argument('-s', '--silent', dest='silent', action='store_true', help='Silent the output')
+    parser.add_argument('-d', '--dryrun', dest='dryrun', action='store_true', help='Dont actually build or push, useful for testing')
+    parser.add_argument('-p', '--prefix', dest='prefix', action='store', default='', help='Override docker prefix from empty (docker hub)')
+    args = parser.parse_args()
+
     r = requests.get("https://ftb.cursecdn.com/FTB2/static/modpacks.xml")
     tree = bs4.BeautifulSoup(r.text, "html.parser")
 
+    modpacks = {}
     for packelm in tree.find_all('modpack'):
         modpack = Modpack(
             name=packelm.get('name'),
@@ -82,6 +128,11 @@ def main():
             server_pack=packelm.get('serverpack'),
             repo_version=packelm.get('repoversion')
         )
+        if args.modpack and modpack.dir.lower() != args.modpack.lower():
+            continue
+        modpacks[modpack.dir] = modpack
+
+    for key, modpack in modpacks.items():
         build_modpack(modpack)
 
 

--- a/modserver/Dockerfile
+++ b/modserver/Dockerfile
@@ -1,6 +1,7 @@
 FROM feedthebeast/ftbbase
 
 ARG DOWNLOAD_URL
+ARG DYNMAP_URL
 
 COPY setup.sh ./
 RUN /bin/bash -ex setup.sh && \

--- a/modserver/setup.sh
+++ b/modserver/setup.sh
@@ -6,6 +6,10 @@ if [ -f FTBInstall.sh ]; then
 	/bin/bash FTBInstall.sh >/dev/null 2>&1
 fi
 
+if [ ! -z "${DYNMAP_URL}" ]; then
+	wget -qO mods/dynmap.jar $DYNMAP_URL
+fi
+
 echo "eula=true" > eula.txt
 
 if [ ! -f server.properties ] ; then


### PR DESCRIPTION
python ./build.py -h

```
usage: build.py [-h] [-m MODPACK] [-l] [-s] [-d] [-p PREFIX]

optional arguments:
  -h, --help            show this help message and exit
  -m MODPACK, --modpack MODPACK
                        Limit to single modpack
  -l, --latest          Limit to the latest tag for a modpack
  -s, --silent          Silent the output
  -d, --dryrun          Dont actually build or push, useful for testing
  -p PREFIX, --prefix PREFIX
                        Override docker prefix from empty (docker hub)
```

Added a bunch of tooling to make it easier to run single builds for testing
Added dynmap support
Fixed the readme path to the worlds